### PR TITLE
fix:修复跳转逻辑

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -4,8 +4,9 @@
   "description": "Capability for the main window",
   "windows": [
     "main",
-    "menu*",
-    "clipboard"
+    "menu",
+    "clipboard",
+    "preferences"
   ],
   "permissions": [
     "core:default",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
         "skipTaskbar": true,
         "acceptFirstMouse": true,  
         "shadow": false,
-        "resizable": true,
+        "resizable": false,
         "focus": false
       }
     ],

--- a/src/components/ClipboardApp.vue
+++ b/src/components/ClipboardApp.vue
@@ -386,7 +386,7 @@ import { useRouter,useRoute } from 'vue-router'
 import { convertFileSrc, invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import { getCurrentWindow, LogicalSize, LogicalPosition } from '@tauri-apps/api/window';
-import { toggleClipboardWindow } from '../utils/actions.js'
+import { toggleSetWindow } from '../utils/actions.js'
 import { useSettingsStore } from '../stores/settings'
 import { 
   BeakerIcon,
@@ -702,9 +702,8 @@ const togglePinnedView = () => {
 const openSettings = async () => {
   // 移除窗口焦点监听器
   removeWindowListeners()
-
-  router.push('/preferences')
-  showMessage('打开设置')
+  toggleSetWindow()
+  currentWindow.close()
 }
 
 // 复制历史内容
@@ -1470,7 +1469,7 @@ onMounted(async () => {
 
   // 保存当前参数状态
   const shouldShowFavorites = route.query.category === 'favorite'
-  const shouldOpenSettings = route.query.category === 'set'
+
   // 立即清除所有参数
   if (route.query.category) {
     const newQuery = { ...route.query }
@@ -1502,15 +1501,6 @@ onMounted(async () => {
   if (shouldShowFavorites) {
     activeCategory.value = 'favorite'
     console.log('跳转到收藏界面')
-  }
-
-  if (shouldOpenSettings) {
-    console.log('准备打开设置页面')
-    // 使用 setTimeout 确保在下一个事件循环中执行
-    setTimeout(() => {
-      openSettings()
-      console.log('设置页面已打开')
-    }, 50)
   }
   
   // 设置示例数据

--- a/src/components/Preferences.vue
+++ b/src/components/Preferences.vue
@@ -1,12 +1,5 @@
 <template>
   <div class="settings-container">
-    <!-- 设置头部 -->
-    <header class="settings-header">
-      <h1>设置</h1>
-      <button class="back-btn" @click="goBack">← 返回</button>
-    </header>
-
-    <!-- 设置内容区域 -->
     <div class="settings-content">
       <!-- 左侧导航栏 -->
       <nav class="settings-nav">
@@ -1021,13 +1014,14 @@ onMounted(async () => {
   }*/
 
   // await checkAutostartStatus()
-
+/*
   // 初始化窗口大小
   try {
     await currentWindow.setSize(new LogicalSize(800, 580));
   } catch (error) {
     console.error('设置窗口大小失败:', error)
   }
+    */
 })
 
 // 通用设置相关函数

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -75,18 +75,17 @@ export async function createMenuWindow(options = {}) {
  */
 export async function toggleMenuWindow() {
   // 查找已存在的菜单窗口
-  const menuWindows = Array.from(windowInstances.entries())
-    .filter(([key]) => key.startsWith('menu'))
+  const menuWindow = Array.from(windowInstances.entries())
+    .find(([key]) => key === 'menu')
   
-  if (menuWindows.length > 0) {
-    // 如果存在菜单窗口，关闭它们
-    for (const [windowId, window] of menuWindows) {
-      try {
-        await window.close()
-        windowInstances.delete(windowId)
-      } catch (error) {
-        console.error('关闭菜单窗口失败:', error)
-      }
+  if (menuWindow) {
+    // 如果存在菜单窗口，关闭
+    try {
+      const [windowId, window] = menuWindow
+      await window.close()
+      windowInstances.delete(windowId)
+    } catch (error) {
+      console.error('关闭菜单窗口失败:', error)
     }
     return null
   } else {
@@ -120,7 +119,7 @@ export async function toggleMenuWindow() {
 // 新增：更新菜单窗口位置函数
 export async function updateMenuWindowPosition() {
   const menuWindows = Array.from(windowInstances.entries())
-    .filter(([key]) => key.startsWith('menu'))
+    .find(([key]) => key === 'menu')
   
   if (menuWindows.length > 0 && mainWindowPosition) {
     const { x, y, width, height } = mainWindowPosition
@@ -152,7 +151,7 @@ export function hasMenuWindow() {
  */
 export async function updateMenuWindowPositionRealTime() {
   const menuWindows = Array.from(windowInstances.entries())
-    .filter(([key]) => key.startsWith('menu'))
+    .find(([key]) => key === 'menu')
   
   if (menuWindows.length > 0 && mainWindowPosition) {
     const { x, y, width, height } = mainWindowPosition
@@ -224,45 +223,25 @@ export async function createClipboardWindow(options = {}) {
  */
 export async function toggleClipboardWindow() {
   // 查找已存在的剪贴板窗口
-  console.log('🔍 查找已存在的剪贴板窗口...')
-  const clipboardWindows = Array.from(windowInstances.entries())
-    .filter(([key]) => key.startsWith('c'))
-  console.log('正在查找')
-  console.log(clipboardWindows)
-  if (clipboardWindows.length > 0) {
-    // 如果存在剪贴板窗口，关闭它们
-    console.log('存在窗口')
-    for (const [windowId, window] of clipboardWindows) {
-      try {
-        await window.close()
-        windowInstances.delete(windowId)
-        console.log('关闭窗口成功')
-      } catch (error) {
-        console.error('关闭窗口失败:', error)
-      }
+  const clipboardWindow = Array.from(windowInstances.entries())
+    .find(([key]) => key === 'clipboard')
+
+  if (clipboardWindow) {
+    // 如果存在剪贴板窗口，关闭
+    try {
+      const [windowId, window] = clipboardWindow
+      await window.close()
+      windowInstances.delete(windowId)
+    } catch (error) {
+      console.error('关闭剪贴板窗口失败:', error)
     }
     return null
   } else {
     // 如果不存在，创建新窗口
     try {
-      // 使用全局存储的主窗口位置
-      const { x, y, width, height } = mainWindowPosition
-      
-      // 计算新窗口位置（在桌宠右侧）
-      const newX = x + width + 10
-      const newY = y
-      
-      console.log('使用主窗口位置创建剪贴板窗口:', { newX, newY })
-      
-      return await createClipboardWindow({
-        x: newX,
-        y: newY,
-        width: 400,
-        height: 600
-      })
+      await createClipboardWindow() // 创建默认位置的窗口
     } catch (error) {
       console.error('创建剪贴板窗口错误:', error)
-      return await createClipboardWindow() // 创建默认位置的窗口
     }
   }
 }
@@ -320,18 +299,17 @@ export async function createFavoritesWindow(options = {}) {
  */
 export async function toggleFavoritesWindow() {
   // 查找已存在的收藏夹窗口
-  const favoritesWindows = Array.from(windowInstances.entries())
-    .filter(([key]) => key.startsWith('clipboard'))
+  const favoritesWindow = Array.from(windowInstances.entries())
+    .find(([key]) => key === 'clipboard')
   
-  if (favoritesWindows.length > 0) {
-    // 如果存在收藏夹窗口，关闭它们
-    for (const [windowId, window] of favoritesWindows) {
-      try {
-        await window.close()
-        windowInstances.delete(windowId)
-      } catch (error) {
-        console.error('关闭收藏夹窗口失败:', error)
-      }
+  if (favoritesWindow) {
+    // 如果存在收藏夹窗口，关闭
+    try {
+      const [windowId, window] = favoritesWindow
+      await window.close()
+      windowInstances.delete(windowId)
+    } catch (error) {
+      console.error('关闭收藏夹窗口失败:', error)
     }
     return null
   } else {
@@ -359,14 +337,15 @@ export async function toggleFavoritesWindow() {
   }
 }
 
+// 创建设置窗口
 export async function createSetWindow(options = {}) {
-  const windowId = 'clipboard'
+  const windowId = 'preferences'
   
   try {
-    const { x = 100, y = 100, width = 400, height = 600 } = options
+    const { x = 100, y = 100, width = 800, height = 580 } = options
     
     const webview = new WebviewWindow(windowId, {
-      url: '/clipboardapp?category=set', // 直接跳转到剪贴板页面的收藏界面
+      url: '/preferences', // 直接跳转到剪贴板页面的收藏界面
       title: '设置',
       width,
       height,
@@ -375,7 +354,7 @@ export async function createSetWindow(options = {}) {
       resizable: true,
       minimizable: true,
       maximizable: false,
-      decorations: false,
+      decorations: true,
       alwaysOnTop: true,
       skipTaskbar: true,
       hiddenTitle: true,
@@ -408,41 +387,26 @@ export async function createSetWindow(options = {}) {
  */
 export async function toggleSetWindow() {
   // 查找已存在的设置窗口
-  const setsWindows = Array.from(windowInstances.entries())
-    .filter(([key]) => key.startsWith('clipboard'))
+  const setsWindow = Array.from(windowInstances.entries())
+    .find(([key]) => key === 'preferences')
   
-  if (setsWindows.length > 0) {
-    // 如果存在设置窗口，关闭它们
-    for (const [windowId, window] of setsWindows) {
-      try {
-        await window.close()
-        windowInstances.delete(windowId)
-      } catch (error) {
-        console.error('关闭设置窗口失败:', error)
-      }
+  if (setsWindow) {
+    // 如果存在设置窗口，关闭
+    try {
+      const [windowId, window] = setsWindow
+      await window.close()
+      windowInstances.delete(windowId)
+    } catch (error) {
+      console.error('关闭设置窗口失败:', error)
     }
     return null
   } else {
     // 如果不存在，创建新窗口
     try {
-      // 使用全局存储的主窗口位置
-      const { x, y, width, height } = mainWindowPosition
-      
-      // 计算新窗口位置（在桌宠右侧）
-      const newX = x + width + 10
-      const newY = y
-      
-      console.log('使用主窗口位置创建设置窗口:', { newX, newY })
-      
-      return await createSetWindow({
-        x: newX,
-        y: newY,
-        width: 400,
-        height: 600
-      })
+      await createSetWindow() // 创建默认位置的窗口
+
     } catch (error) {
-      console.error('创建收藏夹窗口错误:', error)
-      return await createSetWindow() // 创建默认位置的窗口
+      console.error('创建设置窗口错误:', error)
     }
   }
 }


### PR DESCRIPTION
在主菜单的按钮跳转正常了，给设置界面添加了标题栏，可供拖动